### PR TITLE
Remove postselection from the workflow

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -424,8 +424,7 @@ int main(int argc, char *argv[])
                 // per iteration.
                 std::vector<boost::dynamic_bitset<>> batch;
                 Qiskit::addon::sqd::subsample(
-                    batch, bs_mat_tmp, probs_arr_tmp,
-                    samples_per_batch, rng
+                    batch, bs_mat_tmp, probs_arr_tmp, samples_per_batch, rng
                 );
                 // Write alpha-determinants file for SBD input (includes run id /
                 // iteration for traceability).


### PR DESCRIPTION
Currently, the post-selection has no effect because it runs after configuration recovery, which itself ensures that each bitstring matches the Hamming weight that is required.  In general, post-selection is only necessary during the first iteration of SQD, before occupancy data is known. However, in this demo, we seed with known occupancy data, so configuration recovery can be performed immediately, and post-selection is not needed.

This PR thus removes post-selection from the main loop.