### PR TITLE
Call MPI_Abort on unhandled exception

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -454,11 +454,11 @@ int main(int argc, char *argv[])
         return 0;
     } catch (const std::exception &e) {
         std::cerr << "Unhandled exception in main: " << e.what() << std::endl;
-        MPI_Finalize();
+        MPI_Abort(MPI_COMM_WORLD, 1);
         return 1;
     } catch (...) {
         std::cerr << "Unknown exception in main" << std::endl;
-        MPI_Finalize();
+        MPI_Abort(MPI_COMM_WORLD, 1);
         return 1;
     }
 }


### PR DESCRIPTION
This modifies the code to call `MPI_Abort` if there is an unhandled exception.  Previously it would call `MPI_Finalize`, but this does not ensure that all other MPI ranks terminate, so the job might hang in the case of an error.