### PR TITLE
Add note that python development headers are required

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ To build this project, the following dependencies are required:
 - Rust (latest stable recommended)
 - C compiler with C++17 support
 - CMake and Make (available as RPM packages on RHEL-compatible OS)
-- Python ≥ 3.11
+- Python ≥ 3.11 (including development header files)
 
 
 ## Required Libraries


### PR DESCRIPTION
This change is from a user report, which recommended that users install `libpython3.12-dev`.  That package is specific to Debian distributions, so I thought adding this note would be the best way to handle it.